### PR TITLE
Improve set-environment-variable to reduce chance of errors during use

### DIFF
--- a/jekyll/_cci2/set-environment-variable.adoc
+++ b/jekyll/_cci2/set-environment-variable.adoc
@@ -35,7 +35,7 @@ jobs:
           # available in current step.
           command: |
             echo 'export PATH=/path/to/foo/bin:"$PATH"' >> "$BASH_ENV"
-            echo 'export VERY_IMPORTANT=$(cat important_value)' >> "$BASH_ENV"
+            echo "export VERY_IMPORTANT=$(cat important_value)" >> "$BASH_ENV"
             source "$BASH_ENV"
 ```
 


### PR DESCRIPTION
# Description
Improve the example code used for dynamically using shell script to set ENV.
Use double quotes when command outputs are intended to be loaded into ENV, so that the command is only executed once instead of every time a new shell is spawned.

# Reasons
This reduces the chances for errors to appear which complain about not finding resources in a different directory.

We suffered from this in our CI setup and was greatly puzzled why a non related script was erroring out when we did not call the script. 

This is the original sample code
```
echo 'export VERY_IMPORTANT=$(cat important_value)' >> "$BASH_ENV"
```

After executing the .bashrc file has this line, and if the important_value is actually a filename, then when starting a shell in a directory that doesn't have the file will result in blanks or errors
```
export VERY_IMPORTANT=$(cat important_value)
```

The better example should be using double quotes to evaluate the command first, then save the value in .bashrc
```
export VERY_IMPORTANT=VALUE_CONTENT
```

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x ] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
